### PR TITLE
6 inline functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 /dist
 /tasks.json
 /sequence.json
+/reports.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ git:
   depth: 2
 language: node_js
 node_js:
+  - "6"
   - "5.3"
   - "4.2"

--- a/example.js
+++ b/example.js
@@ -1,16 +1,18 @@
-'use strict';
+// 'use strict';
 
 
 const cb = require('./');
-cb.runner(['js', 'css'], require('./examples/crossbow'))
+cb.runner(['js', 'css', 'shane'], require('./examples/crossbow'))
     .parallel()
-    .filter(x => typeof x.type === 'string')
-    .do(x => {
-        console.log(log(x))
-    })
-    .subscribe();
+    .do(log)
+    .toArray()
+    .subscribe(function (reports) {
+        require('fs').writeFileSync('reports.json', JSON.stringify(reports, null, 2));
+        // console.log(reports);
+    });
 
 function log(x) {
-    // console.log(x.item);
-    return {id: x.item.seqUID, type: x.type, name: x.item.task.taskName}
+    // console.log(`(${x.item.seqUID}) - ${x.type} - ${x.item.task.taskName}`);
+    // console.log(`${x.item.seqUID} `);
 }
+// var meow = require('meow');

--- a/examples/crossbow.js
+++ b/examples/crossbow.js
@@ -21,7 +21,10 @@ module.exports = {
             'test/fixtures/tasks/simple.js'
         ],
         css: ['test/fixtures/tasks/simple.multi.js'],
-        bs: ["test/fixtures/tasks/bs.js"]
+        bs: ["test/fixtures/tasks/bs.js"],
+        shane: function () {
+            console.log('hippies');
+        }
     },
     config: {
         css: {

--- a/examples/crossbow.js
+++ b/examples/crossbow.js
@@ -16,14 +16,17 @@ module.exports = {
     },
     tasks: {
         unit: "@npm sleep 1",
-        buildall: ['js', 'css'],
+        "buildall@p": ['js', 'error', 'css'],
         js: [
             'test/fixtures/tasks/simple.js'
         ],
-        css: ['test/fixtures/tasks/simple.multi.js'],
+        css: ['test/fixtures/tasks/simple.multi.js', 'shane'],
         bs: ["test/fixtures/tasks/bs.js"],
         shane: function () {
             console.log('hippies');
+        },
+        error: function () {
+            throw new Error("some ting");
         }
     },
     config: {

--- a/src/command.run.ts
+++ b/src/command.run.ts
@@ -97,7 +97,7 @@ export default function execute(trigger: CommandTrigger): TaskRunner {
      * to consume. We use the `config.runMode` flag to select a top-level
      * parallel or series runner
      */
-    runner[config.runMode.toLowerCase()]
+    runner[config.runMode]
         .call()
         .do(trigger.tracker)
         /**
@@ -130,7 +130,7 @@ export function handleIncomingRunCommand(cli: Meow, input: CrossbowInput, config
             reporter.reportNoTasksProvided();
             return promptForRunCommand(cli, input, config).then(function (answers) {
                 const cliMerged = merge({}, cli, {input: ['run', ...answers.tasks]});
-                const configMerged = merge({}, config, {runMode: TaskRunModes.Parallel});
+                const configMerged = merge({}, config, {runMode: TaskRunModes.parallel});
                 return execute({
                     shared: new Rx.BehaviorSubject(Immutable.Map({})),
                     cli: cliMerged,

--- a/src/command.run.ts
+++ b/src/command.run.ts
@@ -6,7 +6,7 @@ const merge = require('lodash.merge');
 
 import {Meow, CrossbowInput} from './index';
 import {CrossbowConfiguration} from './config';
-import {resolveTasks} from './task.resolve';
+import {resolveTasks, TaskRunModes} from './task.resolve';
 import {TaskRunner, TaskReport} from './task.runner';
 import Immutable = require('immutable');
 
@@ -97,7 +97,7 @@ export default function execute(trigger: CommandTrigger): TaskRunner {
      * to consume. We use the `config.runMode` flag to select a top-level
      * parallel or series runner
      */
-    runner[config.runMode]
+    runner[config.runMode.toLowerCase()]
         .call()
         .do(trigger.tracker)
         /**
@@ -130,7 +130,7 @@ export function handleIncomingRunCommand(cli: Meow, input: CrossbowInput, config
             reporter.reportNoTasksProvided();
             return promptForRunCommand(cli, input, config).then(function (answers) {
                 const cliMerged = merge({}, cli, {input: ['run', ...answers.tasks]});
-                const configMerged = merge({}, config, {runMode: 'parallel'});
+                const configMerged = merge({}, config, {runMode: TaskRunModes.Parallel});
                 return execute({
                     shared: new Rx.BehaviorSubject(Immutable.Map({})),
                     cli: cliMerged,

--- a/src/command.run.ts
+++ b/src/command.run.ts
@@ -98,7 +98,7 @@ export default function execute(trigger: CommandTrigger): TaskRunner {
      * parallel or series runner
      */
     runner[config.runMode]
-        .call(null, trigger.tracker$)
+        .call()
         .do(trigger.tracker)
         /**
          * Now dicard anything that is not a start/error/begin event

--- a/src/command.watch.ts
+++ b/src/command.watch.ts
@@ -145,7 +145,7 @@ export default function execute(trigger: CommandTrigger): WatchTaskRunner {
 
         return before
             .runner
-            .Series()
+            .series()
             .filter(isReport)
             .do(report => {
                 if (trigger.config.progress) {

--- a/src/command.watch.ts
+++ b/src/command.watch.ts
@@ -145,7 +145,7 @@ export default function execute(trigger: CommandTrigger): WatchTaskRunner {
 
         return before
             .runner
-            .series()
+            .Series()
             .filter(isReport)
             .do(report => {
                 if (trigger.config.progress) {

--- a/src/command.watch.ts
+++ b/src/command.watch.ts
@@ -145,7 +145,7 @@ export default function execute(trigger: CommandTrigger): WatchTaskRunner {
 
         return before
             .runner
-            .series(trigger.tracker$) // todo - should this support parallel run mode also?
+            .series()
             .filter(isReport)
             .do(report => {
                 if (trigger.config.progress) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
 /// <reference path="../node_modules/immutable/dist/immutable.d.ts" />
+import {TaskRunModes} from "./task.resolve";
 const assign = require('object-assign');
 
 export interface CrossbowConfiguration {
     logLevel: string
     cwd: string
-    runMode: string
+    runMode: TaskRunModes
     resumeOnError: boolean
     fail: boolean
     summary: string
@@ -32,7 +33,7 @@ const defaults = <CrossbowConfiguration>{
      * one completes. You can set this to 'parallel' instead
      * if you wish for your code to run as fast as possible
      */
-    runMode: 'series',
+    runMode: TaskRunModes.Series,
     resumeOnError: false,
     /**
      * How much task information should be output
@@ -89,7 +90,7 @@ const flagTransforms = {
      * -p changes 'runMode' from series to parallel
      */
     p: (opts) => {
-        return assign({}, opts, {runMode: 'parallel'});
+        return assign({}, opts, {runMode: TaskRunModes.Parallel});
     },
     /**
      * -c specifies a config file

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ const defaults = <CrossbowConfiguration>{
      * one completes. You can set this to 'parallel' instead
      * if you wish for your code to run as fast as possible
      */
-    runMode: TaskRunModes.Series,
+    runMode: TaskRunModes.series,
     resumeOnError: false,
     /**
      * How much task information should be output
@@ -90,7 +90,7 @@ const flagTransforms = {
      * -p changes 'runMode' from series to parallel
      */
     p: (opts) => {
-        return assign({}, opts, {runMode: TaskRunModes.Parallel});
+        return assign({}, opts, {runMode: TaskRunModes.parallel});
     },
     /**
      * -c specifies a config file

--- a/src/reporters/defaultReporter.ts
+++ b/src/reporters/defaultReporter.ts
@@ -255,7 +255,7 @@ export function logWatchErrors(tasks: WatchTask[], indent: string): void {
                 label: `{yellow:+ input: '${task.name}'}`, nodes: [
                     {
                         label: [
-                            `{red.bold:x [${task.name}]}`,
+                            `{red.bold:x ${task.name}}`,
                             getWatchError(task.errors[0], task)
                         ].join('\n')
                     }
@@ -385,9 +385,9 @@ function getSequenceLabel(item: SequenceItem, config: CrossbowConfiguration) {
         return item.task.taskName;
     }
     if (item.items.length === 1) {
-        return compile(`{bold:[${item.taskName}]}`);
+        return compile(`{bold:${item.taskName}}`);
     } else {
-        return compile(`{bold:[${item.taskName}]} {yellow:${SequenceItemTypes[item.type]}}`);
+        return compile(`{bold:${item.taskName}} {yellow:${SequenceItemTypes[item.type]}}`);
     }
 }
 
@@ -475,15 +475,19 @@ function npmScriptLabel(task: Task) {
 
 function getLabel(task) {
 
+    if (task.type === TaskTypes.InlineFunction) {
+        return `${task.taskName}`;
+    }
+
     if (task.origin === TaskOriginTypes.NpmScripts) {
         return npmScriptLabel(task);
     }
 
     if (task.type === TaskTypes.Group) {
         if (task.errors.length) {
-            return `{red.bold:x [${task.taskName}]}`;
+            return `{red.bold:x ${task.taskName}}`;
         }
-        return `{bold:[${task.taskName}]}`;
+        return `{bold:${task.taskName}}`;
     }
 
     if (task.type === TaskTypes.RunnableModule) {

--- a/src/reporters/defaultReporter.ts
+++ b/src/reporters/defaultReporter.ts
@@ -412,7 +412,7 @@ export function reportTaskTree(tasks, config: CrossbowConfiguration, title) {
             }
 
             if (task.type === TaskTypes.Adaptor ||
-                task.type === TaskTypes.Runnable) {
+                task.type === TaskTypes.RunnableModule) {
                 if (task.errors.length) {
                     return acc.concat({
                         label: label,
@@ -486,7 +486,7 @@ function getLabel(task) {
         return `{bold:[${task.taskName}]}`;
     }
 
-    if (task.type === TaskTypes.Runnable) {
+    if (task.type === TaskTypes.RunnableModule) {
         if (task.errors.length) {
             return `{red.bold:x ${task.rawInput}}`;
         }

--- a/src/task.errors.ts
+++ b/src/task.errors.ts
@@ -32,13 +32,21 @@ export function gatherTaskErrors(outgoing: OutgoingTask, input: CrossbowInput): 
 
 function getModuleErrors(outgoing: OutgoingTask): TaskError[] {
     /**
+     * If there are inline functions to execute, this task can never be invalid
+     */
+    if (outgoing.inlineFunctions.length) {
+        return [];
+    }
+    
+    /**
      * If a module was not located, and there are 0 child tasks,
      * this can be classified as a `module not found error`
      */
-    const errors = (outgoing.modules.length === 0 && outgoing.tasks.length === 0)
-        ? [<ModuleNotFoundError>{type: TaskErrorTypes.ModuleNotFound, taskName: outgoing.taskName}]
-        : [];
-    return errors;
+    if (outgoing.modules.length === 0 && outgoing.tasks.length === 0) {
+        return [<ModuleNotFoundError>{type: TaskErrorTypes.ModuleNotFound, taskName: outgoing.taskName}]
+    }
+
+    return [];
 }
 
 function getCBFlagErrors(outgoing: OutgoingTask): TaskError[] {

--- a/src/task.preprocess.ts
+++ b/src/task.preprocess.ts
@@ -1,5 +1,6 @@
 import {Task} from "./task.resolve.d";
 import {CrossbowInput} from "./index";
+import {TaskRunModes} from "./task.resolve";
 
 const assign = require('object-assign');
 const qs = require('qs');
@@ -164,9 +165,12 @@ function getSplitFlags(taskName: string, input: CrossbowInput): SplitTaskAndFlag
  */
 function processFlags(incoming: IncomingTask): OutgoingTask {
 
-    const runMode = incoming.cbflags.indexOf('p') > -1
-        ? 'parallel'
-        : 'series';
+    const runMode = (function () {
+        if (incoming.cbflags.indexOf('p') > -1) {
+            return TaskRunModes.Parallel;
+        }
+        return TaskRunModes.Series;
+    })();
 
     return assign({}, incoming, {
         runMode
@@ -204,8 +208,8 @@ function getBaseNameAndFlags(taskName: string): {baseName: string, flags: {}} {
     } else {
         baseName = splitFlags[1];
         if (splitFlags.length === 3) {
-            const mini = require('yargs-parser');
-            flags = withoutCommand(mini(splitFlags[2]));
+            const yargsParser = require('yargs-parser');
+            flags = withoutCommand(yargsParser(splitFlags[2]));
         }
     }
     return {baseName, flags};

--- a/src/task.preprocess.ts
+++ b/src/task.preprocess.ts
@@ -167,9 +167,9 @@ function processFlags(incoming: IncomingTask): OutgoingTask {
 
     const runMode = (function () {
         if (incoming.cbflags.indexOf('p') > -1) {
-            return TaskRunModes.Parallel;
+            return TaskRunModes.parallel;
         }
-        return TaskRunModes.Series;
+        return TaskRunModes.series;
     })();
 
     return assign({}, incoming, {

--- a/src/task.preprocess.ts
+++ b/src/task.preprocess.ts
@@ -15,6 +15,7 @@ export interface IncomingTask {
     cbflags: string[]
     modules?: string[]
     tasks?: Task[]
+    inlineFunctions: any[]
     query: any
 }
 
@@ -47,7 +48,7 @@ export function preprocessTask(taskName: string, input: CrossbowInput): Outgoing
      */
     const baseTaskName = splitTask[0];
     const subTasks = splitTask.slice(1);
-
+    
     /**
      * Create the base task
      * @type {IncomingTask}
@@ -60,7 +61,8 @@ export function preprocessTask(taskName: string, input: CrossbowInput): Outgoing
         subTasks,
         taskName: baseTaskName,
         rawInput: taskName,
-        tasks: []
+        tasks: [],
+        inlineFunctions: []
     };
 
     /**

--- a/src/task.resolve.d.ts
+++ b/src/task.resolve.d.ts
@@ -1,5 +1,5 @@
 import {TaskError} from "./task.errors.d";
-import {TaskOriginTypes, TaskTypes} from "./task.resolve";
+import {TaskOriginTypes, TaskTypes, TaskRunModes} from "./task.resolve";
 
 export interface Task {
     valid: boolean
@@ -12,7 +12,7 @@ export interface Task {
     errors: TaskError[]
     adaptor?: string
     command?: string
-    runMode: string
+    runMode: TaskRunModes
     startTime?: number
     endTime?: number
     duration?: number

--- a/src/task.resolve.d.ts
+++ b/src/task.resolve.d.ts
@@ -20,6 +20,7 @@ export interface Task {
     flags: any
     origin: TaskOriginTypes
     type: TaskTypes
+    inlineFunctions: Array<()=>void>
 }
 
 export interface TasknameWithOrigin {

--- a/src/task.resolve.ts
+++ b/src/task.resolve.ts
@@ -184,6 +184,13 @@ function resolveChildTasks(initialTasks: any[], taskName: string, parents: strin
             return flat;
         }
 
+        /**
+         * Never try to resolve children tasks if this is an Inline Function
+         */
+        if (flat.type === TaskTypes.InlineFunction) {
+            return flat;
+        }
+
         if (!flat.modules.length) {
             flat.tasks = resolveChildTasks(flat.tasks, item, parents.concat(taskName), trigger);
         }
@@ -233,6 +240,7 @@ function createAdaptorTask(taskName, parents): Task {
         taskName: taskName,
         subTasks: [],
         modules: [],
+        inlineFunctions: [],
         tasks: [],
         rawInput: taskName,
         parents: parents,

--- a/src/task.resolve.ts
+++ b/src/task.resolve.ts
@@ -7,15 +7,16 @@ import {TaskErrorTypes, gatherTaskErrors} from "./task.errors";
 import {locateModule} from "./task.utils";
 import * as adaptors from "./adaptors";
 
-import {preprocessTask, removeNewlines} from "./task.preprocess";
+import {preprocessTask, removeNewlines, OutgoingTask} from "./task.preprocess";
 import {CrossbowInput} from "./index";
 import {CommandTrigger} from "./command.run";
 import {Task, TasknameWithOrigin, Tasks} from "./task.resolve.d";
 
 export enum TaskTypes {
-    Runnable = <any>"Runnable",
-    Adaptor = <any>"Adaptor",
-    Group = <any>"Group"
+    RunnableModule = <any>"RunnableModule",
+    Adaptor  = <any>"Adaptor",
+    Group    = <any>"Group",
+    InlineFunction = <any>"InlineFunction"
 }
 
 export enum TaskOriginTypes {
@@ -47,10 +48,22 @@ function createTask(obj: any): Task {
     return merge({}, defaultTask, obj);
 }
 
+function locateInlineFunctions(incoming: OutgoingTask, input: CrossbowInput) : any[] {
+    const maybe = input.tasks[incoming.baseTaskName];
+    if (typeof maybe === 'function') {
+        return [maybe];
+    }
+    return [];
+}
+
 /**
  * Entry point for all tasks
  */
 function createFlattenedTask(taskName: string, parents: string[], trigger: CommandTrigger): Task {
+
+    /** DEBUG **/
+    debug(`resolving ('${typeof taskName}') ${taskName}`);
+    /** DEBUG-END **/
 
     /**
      * Remove any newlines on incoming task names
@@ -76,6 +89,10 @@ function createFlattenedTask(taskName: string, parents: string[], trigger: Comma
      */
     const incoming = preprocessTask(taskName, trigger.input);
 
+    /** DEBUG **/
+    debug(`preprocessed '${taskName}'`, incoming);
+    /** DEBUG-END **/
+
     /**
      * Try to locate modules/files using the cwd + the current
      * task name. This happens as a first pass so that local files
@@ -86,14 +103,29 @@ function createFlattenedTask(taskName: string, parents: string[], trigger: Comma
      * @type {Array}
      */
     incoming.modules = locateModule(trigger.config.cwd, incoming.baseTaskName);
+    debug('Located modules', incoming.modules.length);
 
     /**
      * Resolve any child tasks if no modules were found, this is the core of how the recursive
      * alias's work
      */
-    // todo unit test this logic - or even better make it obsolete
     if (!incoming.modules.length) {
-        incoming.tasks = resolveChildTasks([], incoming.baseTaskName, parents, trigger);
+
+        /**
+         * Now try to locate inline functions
+         * @type {Array}
+         */
+        incoming.inlineFunctions = locateInlineFunctions(incoming, trigger.input);
+        debug('Located inline functions', incoming.inlineFunctions.length);
+
+        if (!incoming.inlineFunctions.length) {
+
+            /**
+             * Finally, it probably has nested tasks
+             * @type {Task[]}
+             */
+            incoming.tasks = resolveChildTasks([], incoming.baseTaskName, parents, trigger);
+        }
     }
 
     const errors = gatherTaskErrors(
@@ -101,9 +133,17 @@ function createFlattenedTask(taskName: string, parents: string[], trigger: Comma
         trigger.input
     );
 
-    const type = incoming.modules.length
-        ? TaskTypes.Runnable
-        : TaskTypes.Group;
+    const type = (function(){
+        if (incoming.modules.length) {
+            return TaskTypes.RunnableModule;
+        }
+        if (incoming.inlineFunctions.length) {
+            return TaskTypes.InlineFunction;
+        }
+        return TaskTypes.Group;
+    })();
+
+    debug(`Setting type ${type}`);
 
     return createTask(assign({}, incoming, {
         parents,
@@ -281,6 +321,22 @@ function validateTask(task: Task, trigger: CommandTrigger): boolean {
         if (adaptors[<any>task.adaptor]) {
             return adaptors[<any>task.adaptor].validate.apply(null, [task, trigger]);
         }
+    }
+
+    /**
+     * If this task was set to InlineFunction, it's always valid
+     * (as there's a function to call)
+     */
+    if (task.type === TaskTypes.InlineFunction) {
+        return true;
+    }
+
+    /**
+     * If the task has external modules associated
+     * with it, it's always valid (as it has things to run)
+     */
+    if (task.type === TaskTypes.RunnableModule) {
+        return true;
     }
 
     /**

--- a/src/task.resolve.ts
+++ b/src/task.resolve.ts
@@ -27,13 +27,8 @@ export enum TaskOriginTypes {
 }
 
 export enum TaskRunModes {
-    Series = <any>"Series",
-    Parallel = <any>"Parallel",
-}
-
-export enum TaskStatusTypes {
-    Series = <any>"Series",
-    Parallel = <any>"Parallel",
+    series = <any>"series",
+    parallel = <any>"Parallel",
 }
 
 const defaultTask = <Task>{
@@ -45,7 +40,7 @@ const defaultTask = <Task>{
     tasks: [],
     parents: [],
     errors: [],
-    runMode: TaskRunModes.Series
+    runMode: TaskRunModes.series
 };
 
 
@@ -256,7 +251,7 @@ function createAdaptorTask(taskName, parents): Task {
         parents: parents,
         errors: [],
         command: commandInput,
-        runMode: TaskRunModes.Series,
+        runMode: TaskRunModes.series,
         query: {},
         flags: {},
         origin: TaskOriginTypes.Adaptor,

--- a/src/task.resolve.ts
+++ b/src/task.resolve.ts
@@ -28,7 +28,7 @@ export enum TaskOriginTypes {
 
 export enum TaskRunModes {
     series = <any>"series",
-    parallel = <any>"Parallel",
+    parallel = <any>"parallel",
 }
 
 const defaultTask = <Task>{

--- a/src/task.resolve.ts
+++ b/src/task.resolve.ts
@@ -26,6 +26,16 @@ export enum TaskOriginTypes {
     Adaptor = <any>"Adaptor"
 }
 
+export enum TaskRunModes {
+    Series = <any>"Series",
+    Parallel = <any>"Parallel",
+}
+
+export enum TaskStatusTypes {
+    Series = <any>"Series",
+    Parallel = <any>"Parallel",
+}
+
 const defaultTask = <Task>{
     valid: false,
     rawInput: '',
@@ -35,7 +45,7 @@ const defaultTask = <Task>{
     tasks: [],
     parents: [],
     errors: [],
-    runMode: 'series'
+    runMode: TaskRunModes.Series
 };
 
 
@@ -246,7 +256,7 @@ function createAdaptorTask(taskName, parents): Task {
         parents: parents,
         errors: [],
         command: commandInput,
-        runMode: 'series',
+        runMode: TaskRunModes.Series,
         query: {},
         flags: {},
         origin: TaskOriginTypes.Adaptor,

--- a/src/task.runner.ts
+++ b/src/task.runner.ts
@@ -94,10 +94,10 @@ export function createObservableFromSequenceItem(item: SequenceItem, trigger: Co
                         }
                     });
                     single.setDisposable(dis);
-                    return single
+                    return single;
                 }
             }
-            return handleReturn(output, observer);
+            handleReturn(output, observer);
         }
 
         /**
@@ -106,7 +106,7 @@ export function createObservableFromSequenceItem(item: SequenceItem, trigger: Co
          * we can complete the task immediately
          */
         if (item.factory.length < 3) {
-            return observer.onCompleted();
+            return observer.done();
         }
 
     }).catch(error => {

--- a/src/task.sequence.ts
+++ b/src/task.sequence.ts
@@ -40,7 +40,7 @@ export function createFlattenedSequence(tasks: Task[], trigger: CommandTrigger):
                  * If the current task was marked as `parallel`, all immediate children
                  * of (this task) will be run in `parallel`
                  */
-                if (task.runMode === TaskRunModes.Parallel) {
+                if (task.runMode === TaskRunModes.parallel) {
                     return all.concat(createSequenceParallelGroup({
                         taskName: task.taskName,
                         items: flatten(task.tasks, [])
@@ -51,7 +51,7 @@ export function createFlattenedSequence(tasks: Task[], trigger: CommandTrigger):
                  * will be queued and run in series - each waiting until the previous
                  * one has completed
                  */
-                if (task.runMode === TaskRunModes.Series) {
+                if (task.runMode === TaskRunModes.series) {
                     return all.concat(createSequenceSeriesGroup({
                         taskName: task.taskName,
                         items: flatten(task.tasks, []),
@@ -269,7 +269,7 @@ export function createRunner(items: SequenceItem[], trigger: CommandTrigger): Ru
      * error should not adversely affect sibling tasks
      */
     function shouldCatch(trigger) {
-        return trigger.config.runMode === TaskRunModes.Parallel;
+        return trigger.config.runMode === TaskRunModes.parallel;
     }
 
     /**

--- a/test/command.run.gather.js
+++ b/test/command.run.gather.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert;
 const cli = require("../");
+const TaskRunModes = require('../dist/task.resolve').TaskRunModes;
 
 function handoff(cmd, input, cb) {
     return cli({
@@ -104,7 +105,7 @@ describe('Gathering run tasks (1)', function () {
             }
         });
 
-        assert.equal(runner.tasks.valid[0].runMode, 'parallel');
-        assert.equal(runner.tasks.valid[0].tasks[0].runMode, 'series');
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Parallel);
+        assert.equal(runner.tasks.valid[0].tasks[0].runMode, TaskRunModes.Series);
     });
 });

--- a/test/command.run.gather.js
+++ b/test/command.run.gather.js
@@ -107,16 +107,4 @@ describe('Gathering run tasks (1)', function () {
         assert.equal(runner.tasks.valid[0].runMode, 'parallel');
         assert.equal(runner.tasks.valid[0].tasks[0].runMode, 'series');
     });
-    it.only('can resolve tasks with inline functions', function () {
-        const runner = cli.getRunner(['js'], {
-            tasks: {
-                js: function (opts) {
-
-                }
-            }
-        });
-
-        assert.equal(runner.tasks.valid[0].runMode, 'series');
-        // assert.equal(runner.tasks.valid[0].tasks[0].runMode, 'series');
-    });
 });

--- a/test/command.run.gather.js
+++ b/test/command.run.gather.js
@@ -105,7 +105,7 @@ describe('Gathering run tasks (1)', function () {
             }
         });
 
-        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Parallel);
-        assert.equal(runner.tasks.valid[0].tasks[0].runMode, TaskRunModes.Series);
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.parallel);
+        assert.equal(runner.tasks.valid[0].tasks[0].runMode, TaskRunModes.series);
     });
 });

--- a/test/command.run.gather.js
+++ b/test/command.run.gather.js
@@ -107,4 +107,16 @@ describe('Gathering run tasks (1)', function () {
         assert.equal(runner.tasks.valid[0].runMode, 'parallel');
         assert.equal(runner.tasks.valid[0].tasks[0].runMode, 'series');
     });
+    it.only('can resolve tasks with inline functions', function () {
+        const runner = cli.getRunner(['js'], {
+            tasks: {
+                js: function (opts) {
+
+                }
+            }
+        });
+
+        assert.equal(runner.tasks.valid[0].runMode, 'series');
+        // assert.equal(runner.tasks.valid[0].tasks[0].runMode, 'series');
+    });
 });

--- a/test/command.run.gather.preprocess.js
+++ b/test/command.run.gather.preprocess.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert;
 const preprocess = require('../dist/task.preprocess').preprocessTask;
+const TaskRunModes = require('../dist/task.resolve').TaskRunModes;
 
 describe('can pre-process incoming task names', function () {
     it('can handle simple tasks tasks', function () {
@@ -10,7 +11,7 @@ describe('can pre-process incoming task names', function () {
                 flags: {},
                 baseTaskName: 'file.js',
                 subTasks: [],
-                runMode: 'Series',
+                runMode: TaskRunModes.series,
                 rawInput: 'file.js',
                 taskName: 'file.js',
                 query: {},

--- a/test/command.run.gather.preprocess.js
+++ b/test/command.run.gather.preprocess.js
@@ -10,7 +10,7 @@ describe('can pre-process incoming task names', function () {
                 flags: {},
                 baseTaskName: 'file.js',
                 subTasks: [],
-                runMode: 'series',
+                runMode: 'Series',
                 rawInput: 'file.js',
                 taskName: 'file.js',
                 query: {},
@@ -20,7 +20,6 @@ describe('can pre-process incoming task names', function () {
         );
     });
     it('can handle single subtask', function () {
-
         const proc = preprocess('file.js:dev', {tasks:{}});
         assert.equal(proc.baseTaskName, 'file.js');
         assert.deepEqual(proc.subTasks, ['dev']);

--- a/test/command.run.gather.preprocess.js
+++ b/test/command.run.gather.preprocess.js
@@ -14,7 +14,8 @@ describe('can pre-process incoming task names', function () {
                 rawInput: 'file.js',
                 taskName: 'file.js',
                 query: {},
-                tasks: []
+                tasks: [],
+                inlineFunctions: []
             }
         );
     });

--- a/test/task.resolve.inline-functions.js
+++ b/test/task.resolve.inline-functions.js
@@ -13,7 +13,7 @@ describe('task.resolve (inline-functions)', function () {
                 }
             }
         });
-        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Series);
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.series);
         assert.equal(runner.tasks.valid[0].flags.shane, true);
     });
     it('with multiple inline functions', function () {
@@ -37,7 +37,7 @@ describe('task.resolve (inline-functions)', function () {
             }
         });
         assert.equal(runner.tasks.valid[0].tasks.length, 2);
-        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Parallel);
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.parallel);
         assert.equal(runner.tasks.valid[0].tasks[0].type, TaskTypes.InlineFunction);
         assert.equal(runner.tasks.valid[0].tasks[1].type, TaskTypes.InlineFunction);
     });

--- a/test/task.resolve.inline-functions.js
+++ b/test/task.resolve.inline-functions.js
@@ -1,6 +1,7 @@
 const assert = require('chai').assert;
 const cli = require("../");
 const TaskTypes = require("../dist/task.resolve").TaskTypes;
+const SequenceItemTypes = require("../dist/task.sequence.factories").SequenceItemTypes;
 
 describe('task.resolve (inline-functions)', function () {
     it('with inline functions', function () {
@@ -49,5 +50,38 @@ describe('task.resolve (inline-functions)', function () {
         });
         assert.equal(runner.tasks.valid[0].tasks[0].flags.production, true);
         assert.equal(runner.tasks.valid[0].tasks[1].query.name, 'shane');
+    });
+    it('creates the correct sequence from tasks', function () {
+        const runner = cli.getRunner(['js'], {
+            tasks: {
+                js: ['shane --production', 'kittie?name=shane'],
+                shane: function ()  {},
+                kittie: function () {}
+            }
+        });
+        assert.equal(runner.sequence[0].type, SequenceItemTypes.SeriesGroup);
+        assert.equal(runner.sequence[0].items.length, 2);
+    });
+    it('sends correct options from config', function () {
+        const runner = cli.getRunner(['js:dev:kittie --production'], {
+            config: {
+                js: {
+                    dev: {
+                        name: "kittie"
+                    },
+                    kittie: {
+                        name: "shane"
+                    }
+                }
+            },
+            tasks: {
+                js: function () {
+
+                }
+            }
+        });
+
+        assert.equal(runner.sequence[0].config.name, 'kittie');
+        assert.equal(runner.sequence[1].config.name, 'shane');
     });
 });

--- a/test/task.resolve.inline-functions.js
+++ b/test/task.resolve.inline-functions.js
@@ -1,0 +1,53 @@
+const assert = require('chai').assert;
+const cli = require("../");
+const TaskTypes = require("../dist/task.resolve").TaskTypes;
+
+describe('task.resolve (inline-functions)', function () {
+    it('with inline functions', function () {
+        const runner = cli.getRunner(['js --shane'], {
+            tasks: {
+                js: function () {
+                    console.log('f11');
+                }
+            }
+        });
+        assert.equal(runner.tasks.valid[0].runMode, 'series');
+        assert.equal(runner.tasks.valid[0].flags.shane, true);
+    });
+    it('with multiple inline functions', function () {
+        const runner = cli.getRunner(['js'], {
+            tasks: {
+                js: ['shane', 'kittie'],
+                shane: function ()  {},
+                kittie: function () {}
+            }
+        });
+        assert.equal(runner.tasks.valid[0].tasks.length, 2);
+        assert.equal(runner.tasks.valid[0].tasks[0].type, TaskTypes.InlineFunction);
+        assert.equal(runner.tasks.valid[0].tasks[1].type, TaskTypes.InlineFunction);
+    });
+    it('with multiple inline functions with cbflags', function () {
+        const runner = cli.getRunner(['js@p'], {
+            tasks: {
+                js: ['shane', 'kittie'],
+                shane: function ()  {},
+                kittie: function () {}
+            }
+        });
+        assert.equal(runner.tasks.valid[0].tasks.length, 2);
+        assert.equal(runner.tasks.valid[0].runMode, 'parallel');
+        assert.equal(runner.tasks.valid[0].tasks[0].type, TaskTypes.InlineFunction);
+        assert.equal(runner.tasks.valid[0].tasks[1].type, TaskTypes.InlineFunction);
+    });
+    it('with flags', function () {
+        const runner = cli.getRunner(['js'], {
+            tasks: {
+                js: ['shane --production', 'kittie?name=shane'],
+                shane: function ()  {},
+                kittie: function () {}
+            }
+        });
+        assert.equal(runner.tasks.valid[0].tasks[0].flags.production, true);
+        assert.equal(runner.tasks.valid[0].tasks[1].query.name, 'shane');
+    });
+});

--- a/test/task.resolve.inline-functions.js
+++ b/test/task.resolve.inline-functions.js
@@ -1,6 +1,7 @@
 const assert = require('chai').assert;
 const cli = require("../");
 const TaskTypes = require("../dist/task.resolve").TaskTypes;
+const TaskRunModes = require("../dist/task.resolve").TaskRunModes;
 const SequenceItemTypes = require("../dist/task.sequence.factories").SequenceItemTypes;
 
 describe('task.resolve (inline-functions)', function () {
@@ -12,7 +13,7 @@ describe('task.resolve (inline-functions)', function () {
                 }
             }
         });
-        assert.equal(runner.tasks.valid[0].runMode, 'series');
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Series);
         assert.equal(runner.tasks.valid[0].flags.shane, true);
     });
     it('with multiple inline functions', function () {
@@ -36,7 +37,7 @@ describe('task.resolve (inline-functions)', function () {
             }
         });
         assert.equal(runner.tasks.valid[0].tasks.length, 2);
-        assert.equal(runner.tasks.valid[0].runMode, 'parallel');
+        assert.equal(runner.tasks.valid[0].runMode, TaskRunModes.Parallel);
         assert.equal(runner.tasks.valid[0].tasks[0].type, TaskTypes.InlineFunction);
         assert.equal(runner.tasks.valid[0].tasks[1].type, TaskTypes.InlineFunction);
     });
@@ -63,7 +64,7 @@ describe('task.resolve (inline-functions)', function () {
         assert.equal(runner.sequence[0].items.length, 2);
     });
     it('sends correct options from config', function () {
-        const runner = cli.getRunner(['js:dev:kittie --production'], {
+        const runner = cli.getRunner(['js:dev:kittie --production', 'test/fixtures/tasks/promise.js --name="shane"'], {
             config: {
                 js: {
                     dev: {
@@ -80,8 +81,9 @@ describe('task.resolve (inline-functions)', function () {
                 }
             }
         });
-
+        assert.equal(runner.sequence.length, 5);
         assert.equal(runner.sequence[0].config.name, 'kittie');
         assert.equal(runner.sequence[1].config.name, 'shane');
+        assert.equal(runner.sequence[2].config.name, 'shane');
     });
 });

--- a/test/task.run.inline-functions.js
+++ b/test/task.run.inline-functions.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert;
 const cli = require("../");
+const TaskErrorTypes = require('../dist/task.errors').TaskErrorTypes;
 
 describe('Running tasks from inline-functions', function () {
     it('with single inline function', function (done) {
@@ -59,11 +60,14 @@ describe('Running tasks from inline-functions', function () {
     });
     it('passes options from config', function (done) {
         const opts = [];
-        const runner = cli.getRunner(['js:dev --production'], {
+        const runner = cli.getRunner(['js:dev:kittie --production'], {
             config: {
                 js: {
                     dev: {
                         input: "src/app.js"
+                    },
+                    kittie: {
+                        input: "src/app2.js"
                     }
                 }
             },
@@ -79,7 +83,27 @@ describe('Running tasks from inline-functions', function () {
             .subscribe(function () {
                 assert.equal(opts[0].input, 'src/app.js');
                 assert.equal(opts[0].production, true);
+                assert.equal(opts[1].input, 'src/app2.js');
+                assert.equal(opts[1].production, true);
                 done();
             });
+    });
+    it('Allows errors when config not defined config ', function () {
+        const opts = [];
+        const runner = cli.getRunner(['js:dev:typo --production'], {
+            config: {
+                js: {
+                    dev: {
+                        input: "src/app.js"
+                    }
+                }
+            },
+            tasks: {
+                js: function (options) {
+                    opts.push(options);
+                }
+            }
+        });
+        assert.equal(runner.tasks.invalid[0].errors[0].type, TaskErrorTypes.SubtaskNotFound);
     });
 });

--- a/test/task.run.inline-functions.js
+++ b/test/task.run.inline-functions.js
@@ -1,0 +1,85 @@
+const assert = require('chai').assert;
+const cli = require("../");
+
+describe('Running tasks from inline-functions', function () {
+    it('with single inline function', function (done) {
+        var called = 0;
+        const runner = cli.getRunner(['js --shane'], {
+            tasks: {
+                js: function () {
+                    called += 1;
+                }
+            }
+        });
+        runner.runner
+            .series()
+            .toArray()
+            .subscribe(function () {
+                assert.equal(called, 1);
+                done();
+            });
+    });
+    it('with multiple inline functions', function (done) {
+        var called = 0;
+        const runner = cli.getRunner(['js --shane', 'js --kittie', 'js'], {
+            tasks: {
+                js: function () {
+                    called += 1;
+                }
+            }
+        });
+        runner.runner
+            .series()
+            .toArray()
+            .subscribe(function () {
+                assert.equal(called, 3);
+                done();
+            });
+    });
+    it('passes options into inline functions', function (done) {
+        const opts = [];
+        const runner = cli.getRunner(['js --name=shane --production', 'js?name=kittie'], {
+            tasks: {
+                js: function (options) {
+                    opts.push(options);
+                }
+            }
+        });
+        runner.runner
+            .series()
+            .toArray()
+            .subscribe(function () {
+                assert.equal(opts[0].name, 'shane');
+                assert.equal(opts[0].production, true);
+
+                assert.equal(opts[1].name, 'kittie');
+                assert.isUndefined(opts[1].production);
+                done();
+            });
+    });
+    it('passes options from config', function (done) {
+        const opts = [];
+        const runner = cli.getRunner(['js:dev --production'], {
+            config: {
+                js: {
+                    dev: {
+                        input: "src/app.js"
+                    }
+                }
+            },
+            tasks: {
+                js: function (options) {
+                    opts.push(options);
+                }
+            }
+        });
+        runner.runner
+            .series()
+            .toArray()
+            .subscribe(function () {
+                assert.equal(opts[0].input, 'src/app.js');
+                assert.equal(opts[0].production, true);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
The following is not implemented yet, but serves as an outline to what will be possible via this PR.

tl;dr - crossbow **can** be used as a drop-in replacement for gulp. With all the excellent reporting, config, task resolution, advanced file-watcher etc

### Configuration
```js
/**
 * Provide optional global config at any point
 */
crossbow.config({
    sass: {
        dev: {
            input: "core/scss",
            output: "css"
        }
    }
});

/**
 * Or require it from a JS file if preferred
 */
crossbow.config(require('./crossbow.js'));

/**
 * If you want YAML instead, use file:<path> syntax.
 * This will instruct crossbow to load & parse a yaml file
 * as your configuration (works with js/json files too)
 */
crossbow.config('file:crossbow.yml');

```

### Tasks
```js
/**
 * Define tasks as normal
 * 'options' here receives any flags/config
 * specified when calling it
 */
crossbow.task('sass', function (options) {
    /**
     * Use vfs.src instead of gulp.src (what gulp uses under the hood)
     */
    return vfs.src(options.input)
      .pipe(sourcemaps.init())
      .pipe(sass().on('error', sass.logError))
      .pipe(post([preimport, cssnano, autoprefixer]))
      .pipe(sourcemaps.write('.'))
      .pipe(vfs.dest(options.output));
});

/**
 * Now, to run sass with the 'dev' config given above
 * followed by another task:
 */
crossbow.task('build-css', ['sass:dev', 'some-other']);

/**
 * Here you can see we run the task 'sass' but with
 * CLI style flags
 */
crossbow.task('build-css', ['sass --input=core/scss --output=css', 'some-other']);

```
### Watch

```js
/**
 * After calling 'watch' with patterns, you have the opportunity
 * to use any of the RxJS operators on the stream (such as debounce)
 */
crossbow.watch(['core/**/*.scss'])
  .debounce(2000)
  .run('sass:dev')
  .run('sass:dev --production')
  .subscribe();
```

### Running tasks in parallel

```js
/**
 * To run 2 tasks in parallel, provide the @p flag on the build-all task
 *
 *    $ crossbow run build-all
 *    -> task 'build-css' and locally installed webpack will be run in parallel
 */
crossbow.task('build-all@p', ['build-css', '@npm webpack']);
```